### PR TITLE
Add environment branding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ NocoBase adopts plugin architecture, all new functions can be realized by develo
 
 ![plugins](https://static-docs.nocobase.com/plugins.png)
 
+## Branding with environment variables
+
+Several environment variables allow overriding branding information shown on the login page and in the footer:
+
+- `BRAND_TEXT` – text displayed as the application title.
+- `BRAND_LOGO_URL` – URL of the logo image.
+- `BRAND_LOGO_PATH` – path to a local logo file used during installation if `BRAND_LOGO_URL` is not provided.
+- `BRAND_POWERED_BY` – HTML string for the footer. `${appVersion}` will be replaced with the app version.
+
 ## Installation
 
 NocoBase supports three installation methods:

--- a/packages/core/client/src/powered-by/index.tsx
+++ b/packages/core/client/src/powered-by/index.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCurrentAppInfo } from '../appInfo/CurrentAppInfoProvider';
 import { usePlugin } from '../application';
+import { useSystemSettings } from '../system-settings';
 import { useToken } from '../style';
 
 export const PoweredBy = () => {
@@ -20,6 +21,7 @@ export const PoweredBy = () => {
   const { token } = useToken();
   const customBrandPlugin: any = usePlugin('@nocobase/plugin-custom-brand');
   const data = useCurrentAppInfo();
+  const systemSettings = useSystemSettings();
   const urls = {
     'en-US': 'https://www.nocobase.com',
     'zh-CN': 'https://www.nocobase.com/cn/',
@@ -36,15 +38,16 @@ export const PoweredBy = () => {
   `;
   const appVersion = `<span class="nb-app-version">v${data?.data?.version}</span>`;
 
+  const brandHtml =
+    systemSettings?.data?.data?.options?.poweredBy ||
+    customBrandPlugin?.options?.options?.brand ||
+    `Powered by <a href="${urls[i18n.language] || urls['en-US']}" target="_blank">NocoBase</a>`;
+
   return (
     <div
       className={cx(style, 'nb-brand')}
       dangerouslySetInnerHTML={{
-        __html: parseHTML(
-          customBrandPlugin?.options?.options?.brand ||
-            `Powered by <a href="${urls[i18n.language] || urls['en-US']}" target="_blank">NocoBase</a>`,
-          { appVersion },
-        ),
+        __html: parseHTML(brandHtml, { appVersion }),
       }}
     ></div>
   );

--- a/packages/plugins/@nocobase/plugin-auth/src/client/pages/AuthLayout.tsx
+++ b/packages/plugins/@nocobase/plugin-auth/src/client/pages/AuthLayout.tsx
@@ -57,6 +57,11 @@ export function AuthLayout() {
       <div style={{ position: 'fixed', top: '2em', right: '2em' }}>
         <SwitchLanguage />
       </div>
+      {data?.data?.logo?.url && (
+        <div style={{ textAlign: 'center', marginBottom: 16 }}>
+          <img src={data.data.logo.url} style={{ maxWidth: 200 }} />
+        </div>
+      )}
       <h1 style={{ textAlign: 'center' }}>
         <ReadPretty.TextArea value={data?.data?.title} />
       </h1>

--- a/packages/plugins/@nocobase/plugin-system-settings/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-system-settings/src/server/server.ts
@@ -19,9 +19,13 @@ export class PluginSystemSettingsServer extends Plugin {
   async install(options?: InstallOptions) {
     const plugin = this.pm.get('file-manager') as PluginFileManagerServer;
     const brandTitle = process.env.BRAND_TEXT || 'App';
+    const logoUrl = process.env.BRAND_LOGO_URL;
     const logoPath = process.env.BRAND_LOGO_PATH;
+    const poweredBy = process.env.BRAND_POWERED_BY;
     let logo;
-    if (logoPath) {
+    if (logoUrl) {
+      logo = { title: 'brand-logo', url: logoUrl };
+    } else if (logoPath) {
       if (plugin) {
         logo = await plugin.createFileRecord({
           filePath: resolve(process.cwd(), logoPath),
@@ -43,6 +47,7 @@ export class PluginSystemSettingsServer extends Plugin {
         title: brandTitle,
         appLang: this.getInitAppLang(options),
         enabledLanguages: [this.getInitAppLang(options)],
+        options: poweredBy ? { poweredBy } : {},
         ...(logo ? { logo } : {}),
       },
     });
@@ -56,7 +61,17 @@ export class PluginSystemSettingsServer extends Plugin {
     });
     const json = instance.toJSON();
     json.raw_title = json.title;
-    json.title = this.app.environment.renderJsonTemplate(instance.title);
+    json.title = process.env.BRAND_TEXT
+      ? process.env.BRAND_TEXT
+      : this.app.environment.renderJsonTemplate(instance.title);
+    if (process.env.BRAND_LOGO_URL) {
+      json.logo = json.logo || {};
+      json.logo.url = process.env.BRAND_LOGO_URL;
+    }
+    if (process.env.BRAND_POWERED_BY) {
+      json.options = json.options || {};
+      json.options.poweredBy = process.env.BRAND_POWERED_BY;
+    }
     return json;
   }
 


### PR DESCRIPTION
## Summary
- allow customizing title, logo and footer via env vars
- show custom brand on login page
- support custom 'Powered by' text
- document branding environment variables

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6840140c590483329a686707e9d1ed60